### PR TITLE
fix: use inline constexpr in header file

### DIFF
--- a/configured_files/config.hpp.in
+++ b/configured_files/config.hpp.in
@@ -4,13 +4,13 @@
 // this is a basic example of how a CMake configured file might look
 // in this particular case, we are using it to set the version number of our executable
 namespace myproject::cmake {
-static constexpr std::string_view project_name = "@PROJECT_NAME@";
-static constexpr std::string_view project_version = "@PROJECT_VERSION@";
-static constexpr int project_version_major { @PROJECT_VERSION_MAJOR@ };
-static constexpr int project_version_minor { @PROJECT_VERSION_MINOR@ };
-static constexpr int project_version_patch { @PROJECT_VERSION_PATCH@ };
-static constexpr int project_version_tweak { @PROJECT_VERSION_TWEAK@ };
-static constexpr std::string_view git_sha = "@GIT_SHA@";
+inline constexpr std::string_view project_name = "@PROJECT_NAME@";
+inline constexpr std::string_view project_version = "@PROJECT_VERSION@";
+inline constexpr int project_version_major { @PROJECT_VERSION_MAJOR@ };
+inline constexpr int project_version_minor { @PROJECT_VERSION_MINOR@ };
+inline constexpr int project_version_patch { @PROJECT_VERSION_PATCH@ };
+inline constexpr int project_version_tweak { @PROJECT_VERSION_TWEAK@ };
+inline constexpr std::string_view git_sha = "@GIT_SHA@";
 }// namespace myproject::cmake
 
 #endif


### PR DESCRIPTION
fixes this [issue](https://github.com/cpp-best-practices/gui_starter_template/issues/232). I will fix other branches, if you think what i am doing is correct.